### PR TITLE
Adding type declaration for setUp

### DIFF
--- a/modules/migrate_embargoes_to_embargo/tests/src/Kernel/PermissionsMapKernelTest.php
+++ b/modules/migrate_embargoes_to_embargo/tests/src/Kernel/PermissionsMapKernelTest.php
@@ -31,7 +31,7 @@ class PermissionsMapKernelTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp() : void {
     parent::setUp();
 
     $module_path = $this->getModulePath('migrate_embargoes_to_embargo');


### PR DESCRIPTION
Corrects the following error:
```
Run PHPUnit tests (base)
  
  Fatal error: Declaration of Drupal\Tests\migrate_embargoes_to_embargo\Kernel\PermissionsMapKernelTest::setUp() must be compatible with Drupal\KernelTests\KernelTestBase::setUp(): void in /__w/embargo/embargo/modules/migrate_embargoes_to_embargo/tests/src/Kernel/PermissionsMapKernelTest.php on line 34
  Error: Process completed with exit code 255.
```