### PR TITLE
Role-based embargo exemption.

### DIFF
--- a/embargo.module
+++ b/embargo.module
@@ -7,6 +7,8 @@
 
 use Drupal\Core\Database\Query\AlterableInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\embargo\EmbargoStorage;
 
@@ -96,4 +98,33 @@ function embargo_theme($existing, $type, $theme, $path) {
       ],
     ],
   ];
+}
+
+/**
+ * Add exempt_roles field.
+ */
+function embargo_update_9101(&$sandbox) {
+  $exempt_roles = BaseFieldDefinition::create('entity_reference')
+    ->setLabel(t('List of exempt roles'))
+    ->setDescription(t('These roles will be able to bypass the embargo.'))
+    ->setTranslatable(FALSE)
+    ->setRevisionable(FALSE)
+    ->setRequired(FALSE)
+    ->setDisplayConfigurable('view', FALSE)
+    ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+    ->setDisplayOptions('form', [
+      'type' => 'entity_reference_autocomplete',
+    ])
+    ->setDisplayOptions('view', [
+      'type' => 'entity_reference_label',
+      'label' => 'hidden',
+    ])
+    ->setSettings([
+      'target_type' => 'user_role',
+      'handler_settings' => [
+        'include_anonymous' => FALSE,
+      ],
+    ]);
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition(
+    'exempt_roles', 'embargo', 'embargo', $exempt_roles);
 }

--- a/src/Access/EmbargoAccessCheck.php
+++ b/src/Access/EmbargoAccessCheck.php
@@ -31,7 +31,7 @@ class EmbargoAccessCheck implements EmbargoAccessCheckInterface {
   protected $request;
 
   /**
-   * Th current user.
+   * The current user.
    *
    * @var \Drupal\Core\Session\AccountInterface
    */

--- a/src/Access/QueryTagger.php
+++ b/src/Access/QueryTagger.php
@@ -194,7 +194,7 @@ class QueryTagger {
 
     // ... the user has a role that is exempted from the embargo.
     $role_alias = $query->leftJoin('embargo__exempt_roles', 'r', 'e.id = %alias.entity_id');
-    $group->condition("{$role_alias}.exempt_roles_target_id",$this->user->getRoles(), 'IN');
+    $group->condition("{$role_alias}.exempt_roles_target_id", $this->user->getRoles(), 'IN');
 
     $query->condition($group);
 

--- a/src/Access/QueryTagger.php
+++ b/src/Access/QueryTagger.php
@@ -192,6 +192,10 @@ class QueryTagger {
     $user_alias = $query->leftJoin('embargo__exempt_users', 'u', 'e.id = %alias.entity_id');
     $group->condition("{$user_alias}.exempt_users_target_id", $this->user->id());
 
+    // ... the user has a role that is exempted from the embargo.
+    $role_alias = $query->leftJoin('embargo__exempt_roles', 'r', 'e.id = %alias.entity_id');
+    $group->condition("{$role_alias}.exempt_roles_target_id",$this->user->getRoles(), 'IN');
+
     $query->condition($group);
 
     return $query;

--- a/src/EmbargoInterface.php
+++ b/src/EmbargoInterface.php
@@ -179,6 +179,24 @@ interface EmbargoInterface extends ContentEntityInterface {
   public function setExemptUsers(array $users): EmbargoInterface;
 
   /**
+   * Gets the list of exempt roles.
+   *
+   * @return \Drupal\user\RoleInterface[]
+   *   A list of roles exempt from the embargo.
+   */
+  public function getExemptRoles(): array;
+
+  /**
+   * Sets the list of roles exempt from this embargo.
+   *
+   * @param array $roles
+   *   A list of role entities to exempt from this embargo.
+   *
+   * @return $this
+   */
+  public function setExemptRoles(array $roles): EmbargoInterface;
+
+  /**
    * Retrieves the node being embargoed.
    *
    * @return \Drupal\node\NodeInterface|null
@@ -237,6 +255,17 @@ interface EmbargoInterface extends ContentEntityInterface {
    *   TRUE if the user is exempt otherwise FALSE.
    */
   public function isUserExempt(AccountInterface $user): bool;
+
+  /**
+   * Checks if any of the user's roles is exempt from this embargo.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The user to check.
+   *
+   * @return bool
+   *   TRUE if the user is exempt otherwise FALSE.
+   */
+  public function isUserRoleExempt(AccountInterface $user): bool;
 
   /**
    * Checks if the given IP address is exempt from this embargo.

--- a/src/EmbargoStorage.php
+++ b/src/EmbargoStorage.php
@@ -109,8 +109,9 @@ class EmbargoStorage extends SqlContentEntityStorage implements EmbargoStorageIn
       $inactive = $embargo->expiresBefore($timestamp);
       $type_exempt = ($entity instanceof NodeInterface && $embargo->getEmbargoType() !== EmbargoInterface::EMBARGO_TYPE_NODE);
       $user_exempt = $embargo->isUserExempt($user);
+      $user_role_exempt = $embargo->isUserRoleExempt($user);
       $ip_exempt = $embargo->ipIsExempt($ip);
-      return !($inactive || $type_exempt || $user_exempt || $ip_exempt);
+      return !($inactive || $type_exempt || $user_exempt || $user_role_exempt|| $ip_exempt);
     });
   }
 

--- a/src/Entity/Embargo.php
+++ b/src/Entity/Embargo.php
@@ -14,6 +14,7 @@ use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Drupal\embargo\EmbargoInterface;
 use Drupal\embargo\IpRangeInterface;
 use Drupal\node\NodeInterface;
+use Drupal\user\RoleInterface;
 use Drupal\user\UserInterface;
 
 /**
@@ -169,6 +170,28 @@ class Embargo extends ContentEntityBase implements EmbargoInterface {
       ])
       ->setSettings([
         'target_type' => 'user',
+        'handler_settings' => [
+          'include_anonymous' => FALSE,
+        ],
+      ]);
+
+    $fields['exempt_roles'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('List of exempt roles'))
+      ->setDescription(t('These roles will be able to bypass the embargo.'))
+      ->setTranslatable(FALSE)
+      ->setRevisionable(FALSE)
+      ->setRequired(FALSE)
+      ->setDisplayConfigurable('view', FALSE)
+      ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+      ->setDisplayOptions('form', [
+        'type' => 'entity_reference_autocomplete',
+      ])
+      ->setDisplayOptions('view', [
+        'type' => 'entity_reference_label',
+        'label' => 'hidden',
+      ])
+      ->setSettings([
+        'target_type' => 'user_role',
         'handler_settings' => [
           'include_anonymous' => FALSE,
         ],
@@ -345,6 +368,23 @@ class Embargo extends ContentEntityBase implements EmbargoInterface {
   /**
    * {@inheritdoc}
    */
+  public function getExemptRoles(): array {
+    /** @var \Drupal\Core\Field\EntityReferenceFieldItemList $exempt_roles */
+    $exempt_roles = $this->get('exempt_roles');
+    return $exempt_roles->referencedEntities();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setExemptRoles(array $roles): EmbargoInterface {
+    $this->set('exempt_roles', $roles);
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getAdditionalEmails(): array {
     return array_map(function ($email) {
       return $email['value'];
@@ -426,6 +466,15 @@ class Embargo extends ContentEntityBase implements EmbargoInterface {
     }, $exempt_users));
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function isUserRoleExempt(AccountInterface $user): bool {
+    $exempt_role_ids = array_map(function (RoleInterface $role) {
+      return $role->id();
+    }, $this->getExemptRoles());
+    return count(array_intersect($exempt_role_ids, $user->getRoles())) > 0;
+  }
   /**
    * {@inheritdoc}
    */

--- a/src/Entity/Embargo.php
+++ b/src/Entity/Embargo.php
@@ -475,6 +475,7 @@ class Embargo extends ContentEntityBase implements EmbargoInterface {
     }, $this->getExemptRoles());
     return count(array_intersect($exempt_role_ids, $user->getRoles())) > 0;
   }
+
   /**
    * {@inheritdoc}
    */


### PR DESCRIPTION
Issue: #27 

This lets you specify roles that are exempt from an embargo. This will help with institutional access to content where users may not be forever responsible for individual objects.

