### PR TITLE
DGI9-521: Improved cacheability.

### DIFF
--- a/embargo.services.yml
+++ b/embargo.services.yml
@@ -38,3 +38,10 @@ services:
       - '@service_container'
     tags:
       - { name: 'event_subscriber' }
+  cache_context.ip.embargo_range:
+    class: Drupal\embargo\Cache\Context\IpRangeCacheContext
+    arguments:
+      - '@request_stack'
+      - '@entity_type.manager'
+    tags:
+      - { name: cache.context }

--- a/src/Cache/Context/IpRangeCacheContext.php
+++ b/src/Cache/Context/IpRangeCacheContext.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\embargo\Cache\Context;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Cache\Context\CacheContextInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Applicable embargo IP range cache context info.
+ */
+class IpRangeCacheContext implements CacheContextInterface {
+
+  /**
+   * Memoized ranges.
+   *
+   * @var \Drupal\embargo\IpRangeInterface[]
+   */
+  protected array $ranges;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    protected RequestStack $requestStack,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    // No-op, other than stashing properties.
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function getLabel() {
+    return \t('Embargo, Applicable IP Ranges');
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getContext() {
+    $range_keys = array_keys($this->getRanges());
+    sort($range_keys, SORT_NUMERIC);
+    return implode(',', $range_keys);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCacheableMetadata() {
+    $cache_meta = new CacheableMetadata();
+
+    foreach ($this->getRanges() as $range) {
+      $cache_meta->addCacheableDependency($range);
+    }
+
+    return $cache_meta;
+  }
+
+  /**
+   * Get any IP range entities associated with the current IP address.
+   *
+   * @return \Drupal\embargo\IpRangeInterface[]
+   *   Any relevant IP range entities.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getRanges() : array {
+    if (!isset($this->ranges)) {
+      /** @var \Drupal\embargo\IpRangeStorageInterface $embargo_ip_range_storage */
+      $embargo_ip_range_storage = $this->entityTypeManager->getStorage('embargo_ip_range');
+      $this->ranges = $embargo_ip_range_storage->getApplicableIpRanges($this->requestStack->getCurrentRequest()
+        ->getClientIp());
+    }
+
+    return $this->ranges;
+  }
+
+}

--- a/src/Entity/IpRange.php
+++ b/src/Entity/IpRange.php
@@ -3,6 +3,7 @@
 namespace Drupal\embargo\Entity;
 
 use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Entity\EntityStorageInterface;
@@ -237,6 +238,15 @@ class IpRange extends ContentEntityBase implements IpRangeInterface {
       return $mask <= 128;
     }
     return FALSE;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCacheContexts() {
+    return Cache::mergeContexts(parent::getCacheContexts(), [
+      'ip.embargo_range',
+    ]);
   }
 
 }

--- a/src/Plugin/search_api/processor/EmbargoProcessor.php
+++ b/src/Plugin/search_api/processor/EmbargoProcessor.php
@@ -251,7 +251,7 @@ class EmbargoProcessor extends ProcessorPluginBase implements ContainerFactoryPl
         $or_group->addCondition($field->getFieldIdentifier(), $ipRange->id());
         $query->addCacheableDependency($ipRange);
       }
-      $query->addCacheContexts(['ip']);
+      $query->addCacheContexts(['ip.embargo_range']);
     }
 
     return (count($or_group->getConditions()) > 0) ? $or_group : NULL;


### PR DESCRIPTION
Having all search result things in the base `ip` context means that things wouldn't be cacheable between IPs; however, we care more about the ranges in which an IP falls for embargo. By rolling a context to wrap around this concept, anonymous results can be cached/used by other clients from the same ranges (including being outside of any specified range).

Unfortunately, the arbitrary "exempt user" thing means that the `user` context will always be applied, affecting the cacheability between different authenticated users; however, if we indeed did something to allow for larger groups of users in aggregate to be granted access? `role` could handle things at the top-level, but might need other capabilities.

---

On further thought, not sure that this would have a huge impact, given this primarily deals with tagging Search API results at the moment; however, most Search API things are not very cacheable.

When/if applying to the other tagged queries, it could make sense; however, [there's not presently a mechanism to nicely tag such queries](https://www.drupal.org/project/drupal/issues/3028976) though we could borrow [an approach used in core](https://www.drupal.org/project/drupal/issues/2557815).