### PR TITLE
SUP-6613: Improve caching

### DIFF
--- a/embargo.services.yml
+++ b/embargo.services.yml
@@ -63,7 +63,7 @@ services:
     tags:
       - { name: 'event_subscriber' }
   cache_context.user.embargo__has_exemption:
-    class: Drupal\embargo\Cache\Context\IpRangeCacheContext
+    class: Drupal\embargo\Cache\Context\UserExemptedCacheContext
     arguments:
       - '@current_user'
       - '@entity_type.manager'

--- a/embargo.services.yml
+++ b/embargo.services.yml
@@ -62,3 +62,10 @@ services:
     class: Drupal\embargo\EventSubscriber\TaggingEventSubscriber
     tags:
       - { name: 'event_subscriber' }
+  cache_context.user.embargo__has_exemption:
+    class: Drupal\embargo\Cache\Context\IpRangeCacheContext
+    arguments:
+      - '@current_user'
+      - '@entity_type.manager'
+    tags:
+      - { name: 'cache.context' }

--- a/modules/migrate_embargoes_to_embargo/src/Plugin/migrate/source/Entity.php
+++ b/modules/migrate_embargoes_to_embargo/src/Plugin/migrate/source/Entity.php
@@ -40,7 +40,7 @@ class Entity extends SourcePluginBase implements ContainerFactoryPluginInterface
     $plugin_id,
     $plugin_definition,
     MigrationInterface $migration,
-    EntityTypeManagerInterface $entity_type_manager
+    EntityTypeManagerInterface $entity_type_manager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $migration);
 
@@ -56,7 +56,7 @@ class Entity extends SourcePluginBase implements ContainerFactoryPluginInterface
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    MigrationInterface $migration = NULL
+    MigrationInterface $migration = NULL,
   ) {
     return new static(
       $configuration,

--- a/src/Access/EmbargoAccessCheck.php
+++ b/src/Access/EmbargoAccessCheck.php
@@ -62,6 +62,11 @@ class EmbargoAccessCheck implements EmbargoAccessCheckInterface {
       ->addCacheTags($type->getListCacheTags())
       ->addCacheContexts($type->getListCacheContexts());
 
+    if ($user->hasPermission('bypass embargo access')) {
+      return $state->setReason('User has embargo bypass permission.')
+        ->addCacheContexts(['user.permissions']);
+    }
+
     /** @var \Drupal\embargo\EmbargoStorage $storage */
     $storage = $this->entityTypeManager->getStorage('embargo');
     $related_embargoes = $storage->getApplicableEmbargoes($entity);

--- a/src/Access/EmbargoAccessCheck.php
+++ b/src/Access/EmbargoAccessCheck.php
@@ -58,9 +58,7 @@ class EmbargoAccessCheck implements EmbargoAccessCheckInterface {
    */
   public function access(EntityInterface $entity, AccountInterface $user) {
     $type = $this->entityTypeManager->getDefinition('embargo');
-    $state = AccessResult::neutral()
-      ->addCacheTags($type->getListCacheTags())
-      ->addCacheContexts($type->getListCacheContexts());
+    $state = AccessResult::neutral();
 
     if ($user->hasPermission('bypass embargo access')) {
       return $state->setReason('User has embargo bypass permission.')
@@ -69,6 +67,8 @@ class EmbargoAccessCheck implements EmbargoAccessCheckInterface {
 
     /** @var \Drupal\embargo\EmbargoStorage $storage */
     $storage = $this->entityTypeManager->getStorage('embargo');
+    $state->addCacheTags($type->getListCacheTags())
+      ->addCacheContexts($type->getListCacheContexts());
     $related_embargoes = $storage->getApplicableEmbargoes($entity);
     if (empty($related_embargoes)) {
       return $state->setReason('No embargo statements for the given entity.');

--- a/src/Cache/Context/UserExemptedCacheContext.php
+++ b/src/Cache/Context/UserExemptedCacheContext.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\embargo\Cache\Context;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Cache\Context\CacheContextInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Context based of the given user being exempt from _any_ embargoes.
+ */
+class UserExemptedCacheContext implements CacheContextInterface {
+
+  /**
+   * Memoize if exempted.
+   *
+   * @var bool
+   */
+  protected bool $exempted;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(
+    protected AccountInterface $currentUser,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    // No-op, other than stashing properties.
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function getLabel() {
+    return \t('User, has any embargo exemptions');
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getContext() {
+    return $this->isExempted() ? '1' : '0';
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCacheableMetadata() {
+    return (new CacheableMetadata())
+      ->addCacheContexts([$this->isExempted() ? 'user' : 'user.permissions'])
+      ->addCacheTags(['embargo_list']);
+  }
+
+  /**
+   * Determine if the current user has _any_ exemptions.
+   *
+   * @return bool
+   *   TRUE if the user is exempt to at least one embargo; otherwise, FALSE.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function isExempted() : bool {
+    if (!isset($this->exempted)) {
+      $results = $this->entityTypeManager->getStorage('embargo')->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('exempt_users', $this->currentUser->id())
+        ->range(0, 1)
+        ->execute();
+      $this->exempted = !empty($results);
+    }
+
+    return $this->exempted;
+  }
+
+}

--- a/src/Entity/IpRange.php
+++ b/src/Entity/IpRange.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\embargo\EmbargoStorageInterface;
 use Drupal\embargo\IpRangeInterface;
 use Symfony\Component\HttpFoundation\IpUtils;
 
@@ -40,7 +41,6 @@ use Symfony\Component\HttpFoundation\IpUtils;
  *       "html" = "Drupal\Core\Entity\Routing\AdminHtmlRouteProvider"
  *     },
  *   },
- *   list_cache_tags = { "node_list", "media_list", "file_list" },
  *   base_table = "embargo_ip_range",
  *   admin_permission = "administer embargo",
  *   entity_keys = {
@@ -248,6 +248,18 @@ class IpRange extends ContentEntityBase implements IpRangeInterface {
     return Cache::mergeContexts(parent::getCacheContexts(), [
       'ip.embargo_range',
     ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getListCacheTagsToInvalidate() : array {
+    return array_merge(
+      parent::getListCacheTagsToInvalidate(),
+      array_map(function (string $type) {
+        return "{$type}_list";
+      }, EmbargoStorageInterface::APPLICABLE_ENTITY_TYPES),
+    );
   }
 
 }

--- a/src/Plugin/search_api/processor/EmbargoJoinProcessor.php
+++ b/src/Plugin/search_api/processor/EmbargoJoinProcessor.php
@@ -289,7 +289,7 @@ class EmbargoJoinProcessor extends ProcessorPluginBase implements ContainerFacto
       // cacheability.
       'ip.embargo_range',
       // Exemptable users, so need to deal with them.
-      'user',
+      'user.embargo__has_exemption',
     ]);
     // Embargo dates deal with granularity to the day.
     $query->mergeCacheMaxAge(24 * 3600);

--- a/tests/src/Kernel/FileEmbargoTest.php
+++ b/tests/src/Kernel/FileEmbargoTest.php
@@ -73,7 +73,7 @@ class FileEmbargoTest extends EmbargoKernelTestBase {
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function testDeletedEmbargoedFileRelatedMediaFileAccessAllowed(
-    $operation
+    $operation,
   ) {
     $node = $this->createNode();
     $file = $this->createFile();


### PR DESCRIPTION
Using the `user` cache context has a negative impact on caching, so let's try to avoid it except where necessary.