### PR TITLE
FDSF-287: module to reindex embargoes.

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,12 +8,9 @@ on:
 
 jobs:
   PHPUnit:
-    uses: discoverygarden/phpunit-action/.github/workflows/phpunit.yml@v1
+    #uses: discoverygarden/phpunit-action/.github/workflows/phpunit.yml@v1
+    uses: discoverygarden/phpunit-action/.github/workflows/phpunit.yml@adam-vessey-patch-1
     secrets: inherit
     with:
-      composer_patches: |-
-        {
-          "discoverygarden/islandora_hierarchical_access": {
-            "dependent work from dependency": "https://github.com/discoverygarden/islandora_hierarchical_access/pull/19.patch"
-          }
-        }
+      composer_prereqs: >-
+        "discoverygarden/islandora_test_support:dev-adam-vessey-patch-1 as 1.x-dev"

--- a/embargo.info.yml
+++ b/embargo.info.yml
@@ -1,7 +1,7 @@
 name: Embargo
 description: 'Embargo content indefinitely or till specified date, limiting access to specific users and/or IP addresses.'
 type: module
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 configure: embargo.settings
 dependencies:
   - drupal:datetime

--- a/modules/migrate_embargoes_to_embargo/migrate_embargoes_to_embargo.info.yml
+++ b/modules/migrate_embargoes_to_embargo/migrate_embargoes_to_embargo.info.yml
@@ -5,6 +5,6 @@ description: >
   Migrations and plugins to handle migrating from the older "embargoes" module
   to this newer "embargo" module.
 package: Embargo
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - embargo:embargo

--- a/modules/migrate_embargoes_to_embargo/src/Plugin/migrate/source/Entity.php
+++ b/modules/migrate_embargoes_to_embargo/src/Plugin/migrate/source/Entity.php
@@ -56,7 +56,7 @@ class Entity extends SourcePluginBase implements ContainerFactoryPluginInterface
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    MigrationInterface $migration = NULL,
+    ?MigrationInterface $migration = NULL,
   ) {
     return new static(
       $configuration,

--- a/modules/reindex_embargoes/README.md
+++ b/modules/reindex_embargoes/README.md
@@ -1,0 +1,26 @@
+# Reindex embargoes
+
+## Introduction
+
+Module that will reindex expired embargoes in search_api. While not directly necessary with the access processors, it will be useful if content is ever indexed to a public index.
+
+## Features
+
+Configuration available to change which search_api index to use:
+`/admin/config/content/embargo/reindex`
+
+## Maintainers and Sponsors
+
+Current maintainers:
+
+* [discoverygarden](http://www.discoverygarden.ca)
+
+## Development/Contribution
+
+If you would like to contribute to this module, please check out github's helpful
+[Contributing to projects](https://docs.github.com/en/get-started/quickstart/contributing-to-projects) documentation and Islandora community's [Documention for developers](https://islandora.github.io/documentation/contributing/CONTRIBUTING/#github-issues) to create an issue or pull request and/or
+contact [discoverygarden](http://support.discoverygarden.ca).
+
+## License
+
+[GPLv3](http://www.gnu.org/licenses/gpl-3.0.txt)

--- a/modules/reindex_embargoes/config/schema/reindex_embargoes.schema.yml
+++ b/modules/reindex_embargoes/config/schema/reindex_embargoes.schema.yml
@@ -1,0 +1,10 @@
+reindex_embargoes.settings:
+  type: config_object
+  label: 'Reindex embargoes settings'
+  mapping:
+    selected_indexes:
+      type: sequence
+      label: 'Selected Search API Indexes'
+      sequence:
+        type: string
+        label: 'Search API Index'

--- a/modules/reindex_embargoes/drush.services.yml
+++ b/modules/reindex_embargoes/drush.services.yml
@@ -1,0 +1,9 @@
+services:
+  reindex_embargoes.commands:
+    class: \Drupal\reindex_embargoes\Drush\Commands\ReindexEmbargoesCommands
+    arguments:
+      - '@entity_type.manager'
+      - '@queue'
+      - '@datetime.time'
+    tags:
+      - { name: drush.command }

--- a/modules/reindex_embargoes/reindex_embargoes.info.yml
+++ b/modules/reindex_embargoes/reindex_embargoes.info.yml
@@ -3,7 +3,7 @@ name: Reindex embargoes
 type: module
 description: 'Module to reindex embargoes.'
 package: Embargo
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - embargo:embargo
   - search_api:search_api

--- a/modules/reindex_embargoes/reindex_embargoes.info.yml
+++ b/modules/reindex_embargoes/reindex_embargoes.info.yml
@@ -3,7 +3,7 @@ name: Reindex embargoes
 type: module
 description: 'Module to reindex embargoes.'
 package: Embargo
-core_version_requirement: ^9 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 dependencies:
   - embargo:embargo
   - search_api:search_api

--- a/modules/reindex_embargoes/reindex_embargoes.info.yml
+++ b/modules/reindex_embargoes/reindex_embargoes.info.yml
@@ -1,0 +1,9 @@
+---
+name: Reindex embargoes
+type: module
+description: 'Module to reindex embargoes.'
+package: Embargo
+core_version_requirement: ^9 || ^10
+dependencies:
+  - embargo:embargo
+  - search_api:search_api

--- a/modules/reindex_embargoes/reindex_embargoes.module
+++ b/modules/reindex_embargoes/reindex_embargoes.module
@@ -5,30 +5,42 @@
  * Hook implementations.
  */
 
-/**
- * Implements hook_cron().
- */
-function reindex_embargoes_cron(): void {
-  $entity_type_manager = \Drupal::entityTypeManager();
-  $queue_factory = \Drupal::service('queue');
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Queue\QueueFactory;
 
-  $request_time = \Drupal::time()->getRequestTime();
-  $next_day = $request_time + 86400;
-
-  // XXX: Dates are stored as varchar, so can't use date comparison.
-  $embargo_ids = $entity_type_manager->getStorage('embargo')->getQuery()
-    ->accessCheck(FALSE)
-    ->condition('embargoed_node', NULL, 'IS NOT NULL')
-    ->execute();
-
-  $queue = $queue_factory->get('embargo_expiration_reindex');
-  $embargoes = $entity_type_manager->getStorage('embargo')->loadMultiple($embargo_ids);
-  foreach ($embargoes as $embargo) {
-    $expiration_date = $embargo->getExpirationDate()->getTimestamp();
-    if ($expiration_date >= $request_time && $expiration_date < $next_day) {
-      $queue->createItem([
-        'embargo_id' => $embargo->id(),
-      ]);
-    }
+function _reindex_embargoes_queue_embargo(EntityInterface $entity, QueueFactory $queue_factory, TimeInterface $time): void {
+  $expiration_date = $entity->getExpirationDate();
+  if (!$expiration_date || !$expiration_date->getTimestamp()) {
+    return;
   }
+
+  $expiration_timestamp = $expiration_date->getTimestamp();
+  $current_timestamp = $time->getRequestTime();
+
+  if ($expiration_timestamp > $current_timestamp) {
+    $queue = $queue_factory->get('embargo_expiration_reindex', TRUE);
+
+    $item = ['embargo_id' => $entity->id()];
+
+    $queue->createItem($item);
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function reindex_embargoes_embargo_insert(EntityInterface $entity): void {
+  $queue_factory = \Drupal::service('queue');
+  $time = \Drupal::service('datetime.time');
+  _reindex_embargoes_queue_embargo($entity, $queue_factory, $time);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function reindex_embargoes_embargo_update(EntityInterface $entity): void {
+  $queue_factory = \Drupal::service('queue');
+  $time = \Drupal::service('datetime.time');
+  _reindex_embargoes_queue_embargo($entity, $queue_factory, $time);
 }

--- a/modules/reindex_embargoes/reindex_embargoes.module
+++ b/modules/reindex_embargoes/reindex_embargoes.module
@@ -15,7 +15,7 @@ function reindex_embargoes_cron(): void {
   $request_time = \Drupal::time()->getRequestTime();
   $next_day = $request_time + 86400;
 
-  // XXX: Dates are stored as varchar in the database, so we need to convert them to timestamps.
+  // XXX: Dates are stored as varchar, so can't use date comparison.
   $embargo_ids = $entity_type_manager->getStorage('embargo')->getQuery()
     ->accessCheck(FALSE)
     ->condition('embargoed_node', NULL, 'IS NOT NULL')

--- a/modules/reindex_embargoes/reindex_embargoes.module
+++ b/modules/reindex_embargoes/reindex_embargoes.module
@@ -9,6 +9,9 @@ use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Queue\QueueFactory;
 
+/**
+ * Generic function to queue embargoes for reindexing.
+ */
 function _reindex_embargoes_queue_embargo(EntityInterface $entity, QueueFactory $queue_factory, TimeInterface $time): void {
   $expiration_date = $entity->getExpirationDate();
   if (!$expiration_date || !$expiration_date->getTimestamp()) {

--- a/modules/reindex_embargoes/reindex_embargoes.module
+++ b/modules/reindex_embargoes/reindex_embargoes.module
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Hook implementations.
+ */
+
+/**
+ * Implements hook_cron().
+ */
+function reindex_embargoes_cron(): void {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $queue_factory = \Drupal::service('queue');
+
+  $request_time = \Drupal::time()->getRequestTime();
+  $next_day = $request_time + 86400;
+
+  $embargo_ids = $entity_type_manager->getStorage('embargo')->getQuery()
+    ->accessCheck(FALSE)
+    ->condition('embargoed_node', NULL, 'IS NOT NULL')
+    ->execute();
+
+  $queue = $queue_factory->get('embargo_expiration_reindex');
+  $embargoes = $entity_type_manager->getStorage('embargo')->loadMultiple($embargo_ids);
+  foreach ($embargoes as $embargo) {
+    $expiration_date = $embargo->getExpirationDate()->getTimestamp();
+    if ($expiration_date >= $request_time && $expiration_date < $next_day) {
+      $queue->createItem([
+        'embargo_id' => $embargo->id(),
+      ]);
+    }
+  }
+}

--- a/modules/reindex_embargoes/reindex_embargoes.module
+++ b/modules/reindex_embargoes/reindex_embargoes.module
@@ -15,6 +15,7 @@ function reindex_embargoes_cron(): void {
   $request_time = \Drupal::time()->getRequestTime();
   $next_day = $request_time + 86400;
 
+  // XXX: Dates are stored as varchar in the database, so we need to convert them to timestamps.
   $embargo_ids = $entity_type_manager->getStorage('embargo')->getQuery()
     ->accessCheck(FALSE)
     ->condition('embargoed_node', NULL, 'IS NOT NULL')

--- a/modules/reindex_embargoes/reindex_embargoes.routing.yml
+++ b/modules/reindex_embargoes/reindex_embargoes.routing.yml
@@ -1,0 +1,7 @@
+reindex_embargoes.settings:
+  path: '/admin/config/content/embargo/reindex'
+  defaults:
+    _form: '\Drupal\reindex_embargoes\Form\SettingsForm'
+    _title: 'Reindex Embargoes'
+  requirements:
+    _permission: 'administer site configuration'

--- a/modules/reindex_embargoes/src/Drush/Commands/ReindexEmbargoesCommands.php
+++ b/modules/reindex_embargoes/src/Drush/Commands/ReindexEmbargoesCommands.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\reindex_embargoes\Drush\Commands;
+
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Component\Datetime\TimeInterface;
+use Drush\Attributes as CLI;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * A Drush command file for reindex_embargoes.
+ */
+class ReindexEmbargoesCommands extends DrushCommands {
+
+  use AutowireTrait;
+
+  /**
+   * ReindexEmbargoesCommands constructor.
+   */
+  public function __construct(
+    #[Autowire(service: 'entity_type.manager')]
+    protected EntityTypeManagerInterface $entityTypeManager,
+    #[Autowire(service: 'queue')]
+    protected QueueFactory $queueFactory,
+    #[Autowire(service: 'datetime.time')]
+    protected TimeInterface $time
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Populates the embargo expiration queue with existing future-dated embargoes.
+   */
+  #[CLI\Command(name: 'reindex_embargoes:populate-queue', aliases: ['r_e:pq'])]
+  public function populateQueue(): void {
+    $this->output()->writeln("Populating Embargo expiration queue...");
+
+    $embargo_storage = $this->entityTypeManager->getStorage('embargo');
+    $queue = $this->queueFactory->get('embargo_expiration_reindex', TRUE);
+    $current_timestamp = $this->time->getRequestTime();
+
+    $current_iso = gmdate('Y-m-d', $current_timestamp);
+
+    $query = $embargo_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('embargoed_node', NULL, 'IS NOT NULL')
+      ->condition('expiration_type', 1, '=')
+      ->condition('expiration_date', NULL, 'IS NOT NULL')
+      ->condition('expiration_date', $current_iso, '>');
+
+    $embargo_ids = $query->execute();
+
+    if (empty($embargo_ids)) {
+      $this->output()->writeln("No future-dated Embargoes found to queue.");
+      return;
+    }
+
+    $this->output()->writeln(dt("Found @count Embargoes with future expiration dates. Processing...", ['@count' => count($embargo_ids)]));
+
+    $embargoes = $embargo_storage->loadMultiple($embargo_ids);
+    $queued_count = 0;
+
+    foreach ($embargoes as $embargo) {
+      $expiration_date_object = $embargo->getExpirationDate();
+      if (!$expiration_date_object || !$expiration_date_object->getTimestamp()) {
+        continue;
+      }
+      $expiration_timestamp = $expiration_date_object->getTimestamp();
+
+      if ($expiration_timestamp > $current_timestamp) {
+        $item = ['embargo_id' => $embargo->id()];
+        $queue->createItem($item);
+        $queued_count++;
+      }
+    }
+
+    $this->output()->writeln(dt("Successfully queued @count Embargoes for future re-indexing.", ['@count' => $queued_count]));
+  }
+
+}

--- a/modules/reindex_embargoes/src/Drush/Commands/ReindexEmbargoesCommands.php
+++ b/modules/reindex_embargoes/src/Drush/Commands/ReindexEmbargoesCommands.php
@@ -26,13 +26,13 @@ class ReindexEmbargoesCommands extends DrushCommands {
     #[Autowire(service: 'queue')]
     protected QueueFactory $queueFactory,
     #[Autowire(service: 'datetime.time')]
-    protected TimeInterface $time
+    protected TimeInterface $time,
   ) {
     parent::__construct();
   }
 
   /**
-   * Populates the embargo expiration queue with existing future-dated embargoes.
+   * Populates the queue with existing future-dated embargoes.
    */
   #[CLI\Command(name: 'reindex_embargoes:populate-queue', aliases: ['r_e:pq'])]
   public function populateQueue(): void {

--- a/modules/reindex_embargoes/src/Drush/Commands/ReindexEmbargoesCommands.php
+++ b/modules/reindex_embargoes/src/Drush/Commands/ReindexEmbargoesCommands.php
@@ -48,7 +48,7 @@ class ReindexEmbargoesCommands extends DrushCommands {
       ->accessCheck(FALSE)
       ->condition('embargoed_node', NULL, 'IS NOT NULL')
       ->condition('expiration_type', 1, '=')
-      ->condition('expiration_date', NULL, 'IS NOT NULL')
+      ->exists('expiration_date')
       ->condition('expiration_date', $current_iso, '>');
 
     $embargo_ids = $query->execute();

--- a/modules/reindex_embargoes/src/Drush/Commands/ReindexEmbargoesCommands.php
+++ b/modules/reindex_embargoes/src/Drush/Commands/ReindexEmbargoesCommands.php
@@ -60,11 +60,10 @@ class ReindexEmbargoesCommands extends DrushCommands {
 
     $this->output()->writeln(dt("Found @count Embargoes with future expiration dates. Processing...", ['@count' => count($embargo_ids)]));
 
-    $embargoes = $embargo_storage->loadMultiple($embargo_ids);
     $queued_count = 0;
 
-    foreach ($embargoes as $embargo) {
-      $item = ['embargo_id' => $embargo->id()];
+    foreach ($embargo_ids as $embargo) {
+      $item = ['embargo_id' => $embargo];
       $queue->createItem($item);
       $queued_count++;
     }

--- a/modules/reindex_embargoes/src/Drush/Commands/ReindexEmbargoesCommands.php
+++ b/modules/reindex_embargoes/src/Drush/Commands/ReindexEmbargoesCommands.php
@@ -64,17 +64,9 @@ class ReindexEmbargoesCommands extends DrushCommands {
     $queued_count = 0;
 
     foreach ($embargoes as $embargo) {
-      $expiration_date_object = $embargo->getExpirationDate();
-      if (!$expiration_date_object || !$expiration_date_object->getTimestamp()) {
-        continue;
-      }
-      $expiration_timestamp = $expiration_date_object->getTimestamp();
-
-      if ($expiration_timestamp > $current_timestamp) {
-        $item = ['embargo_id' => $embargo->id()];
-        $queue->createItem($item);
-        $queued_count++;
-      }
+      $item = ['embargo_id' => $embargo->id()];
+      $queue->createItem($item);
+      $queued_count++;
     }
 
     $this->output()->writeln(dt("Successfully queued @count Embargoes for future re-indexing.", ['@count' => $queued_count]));

--- a/modules/reindex_embargoes/src/Drush/Commands/ReindexEmbargoesCommands.php
+++ b/modules/reindex_embargoes/src/Drush/Commands/ReindexEmbargoesCommands.php
@@ -46,7 +46,7 @@ class ReindexEmbargoesCommands extends DrushCommands {
 
     $query = $embargo_storage->getQuery()
       ->accessCheck(FALSE)
-      ->condition('embargoed_node', NULL, 'IS NOT NULL')
+      ->exists('embargoed_node')
       ->condition('expiration_type', 1, '=')
       ->exists('expiration_date')
       ->condition('expiration_date', $current_iso, '>');

--- a/modules/reindex_embargoes/src/Form/SettingsForm.php
+++ b/modules/reindex_embargoes/src/Form/SettingsForm.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\reindex_embargoes\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\search_api\Entity\Index;
+
+class SettingsForm extends ConfigFormBase {
+    /**
+     * {@inheritdoc}
+     */
+    public function getFormId() {
+        return 'reindex_embargoes_settings';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getEditableConfigNames() {
+        return [
+          'reindex_embargoes.settings',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(array $form, FormStateInterface $form_state) {
+        $config = $this->config('reindex_embargoes.settings');
+
+        $indexes = Index::loadMultiple();
+        $options = [];
+        foreach ($indexes as $index) {
+            $options[$index->id()] = $index->label();
+        }
+
+        $form['selected_indexes'] = [
+          '#type' => 'checkboxes',
+          '#title' => $this->t('Selected indexes'),
+          '#options' => $options,
+          '#default_value' => $config->get('selected_indexes') ?? [],
+          '#description' => $this->t('Select the indexes to be reindexed.'),
+        ];
+
+        return parent::buildForm($form, $form_state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function submitForm(array &$form, FormStateInterface $form_state) {
+      parent::submitForm($form, $form_state);
+      $selected_indexes = $form_state->getValue('selected_indexes');
+      $selected_indexes = array_keys(array_filter($selected_indexes));
+      $this->config('reindex_embargoes.settings')
+        ->set('selected_indexes', $selected_indexes)
+        ->save();
+    }
+}

--- a/modules/reindex_embargoes/src/Form/SettingsForm.php
+++ b/modules/reindex_embargoes/src/Form/SettingsForm.php
@@ -2,14 +2,43 @@
 
 namespace Drupal\reindex_embargoes\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\search_api\Entity\Index;
+use Drupal\search_api\IndexInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Form to configure which indexes to target.
  */
 class SettingsForm extends ConfigFormBase {
+
+  /**
+   * Entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, $typedConfigManager = NULL) {
+    parent::__construct($config_factory, $typedConfigManager);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('entity_type.manager'),
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -33,10 +62,16 @@ class SettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('reindex_embargoes.settings');
 
-    $indexes = Index::loadMultiple();
+    $indexes = $this->entityTypeManager->getStorage('search_api_index')->loadMultiple();
     $options = [];
+
     foreach ($indexes as $index) {
-      $options[$index->id()] = $index->label();
+      if ($index instanceof IndexInterface) {
+        $options[$index->id()] = $index->label();
+        if (!$index->status()) {
+          $options[$index->id()] .= ' (' . $this->t('disabled') . ')';
+        }
+      }
     }
 
     $form['selected_indexes'] = [

--- a/modules/reindex_embargoes/src/Form/SettingsForm.php
+++ b/modules/reindex_embargoes/src/Form/SettingsForm.php
@@ -6,55 +6,60 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\search_api\Entity\Index;
 
+/**
+ * Form to configure which indexes to target.
+ */
 class SettingsForm extends ConfigFormBase {
-    /**
-     * {@inheritdoc}
-     */
-    public function getFormId() {
-        return 'reindex_embargoes_settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'reindex_embargoes_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'reindex_embargoes.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('reindex_embargoes.settings');
+
+    $indexes = Index::loadMultiple();
+    $options = [];
+    foreach ($indexes as $index) {
+      $options[$index->id()] = $index->label();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getEditableConfigNames() {
-        return [
-          'reindex_embargoes.settings',
-        ];
-    }
+    $form['selected_indexes'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Selected indexes'),
+      '#options' => $options,
+      '#default_value' => $config->get('selected_indexes') ?? [],
+      '#description' => $this->t('Select the indexes to be reindexed.'),
+    ];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(array $form, FormStateInterface $form_state) {
-        $config = $this->config('reindex_embargoes.settings');
+    return parent::buildForm($form, $form_state);
+  }
 
-        $indexes = Index::loadMultiple();
-        $options = [];
-        foreach ($indexes as $index) {
-            $options[$index->id()] = $index->label();
-        }
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+    $selected_indexes = $form_state->getValue('selected_indexes');
+    $selected_indexes = array_keys(array_filter($selected_indexes));
+    $this->config('reindex_embargoes.settings')
+      ->set('selected_indexes', $selected_indexes)
+      ->save();
+  }
 
-        $form['selected_indexes'] = [
-          '#type' => 'checkboxes',
-          '#title' => $this->t('Selected indexes'),
-          '#options' => $options,
-          '#default_value' => $config->get('selected_indexes') ?? [],
-          '#description' => $this->t('Select the indexes to be reindexed.'),
-        ];
-
-        return parent::buildForm($form, $form_state);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function submitForm(array &$form, FormStateInterface $form_state) {
-      parent::submitForm($form, $form_state);
-      $selected_indexes = $form_state->getValue('selected_indexes');
-      $selected_indexes = array_keys(array_filter($selected_indexes));
-      $this->config('reindex_embargoes.settings')
-        ->set('selected_indexes', $selected_indexes)
-        ->save();
-    }
 }

--- a/modules/reindex_embargoes/src/Form/SettingsForm.php
+++ b/modules/reindex_embargoes/src/Form/SettingsForm.php
@@ -6,7 +6,6 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\search_api\Entity\Index;
 use Drupal\search_api\IndexInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
+++ b/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
@@ -6,8 +6,9 @@ use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\DelayedRequeueException;
 use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\search_api\IndexInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -36,13 +37,6 @@ class EmbargoExpirationReindex extends QueueWorkerBase implements ContainerFacto
   protected TimeInterface $time;
 
   /**
-   * The queue factory.
-   *
-   * @var \Drupal\Core\Queue\QueueFactory
-   */
-  protected QueueFactory $queueFactory;
-
-  /**
    * The configuration factory.
    *
    * @var \Drupal\Core\Config\ConfigFactoryInterface
@@ -50,51 +44,82 @@ class EmbargoExpirationReindex extends QueueWorkerBase implements ContainerFacto
   protected ConfigFactoryInterface $configFactory;
 
   /**
+   * Constructor.
+   */
+  public function __construct(
+    array $configuration,
+          $plugin_id,
+          $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    TimeInterface $time,
+    ConfigFactoryInterface $config_factory
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+    $this->time = $time;
+    $this->configFactory = $config_factory;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    $instance = new static($configuration, $plugin_id, $plugin_definition);
-
-    $instance->entityTypeManager = $container->get('entity_type.manager');
-    $instance->time = $container->get('datetime.time');
-    $instance->queueFactory = $container->get('queue');
-    $instance->configFactory = $container->get('config.factory');
-    return $instance;
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('datetime.time'),
+      $container->get('config.factory')
+    );
   }
 
   /**
    * {@inheritdoc}
    */
   public function processItem($data): void {
+    if (!isset($data['embargo_id'])) {
+      return;
+    }
+
     $embargo = $this->entityTypeManager->getStorage('embargo')->load($data['embargo_id']);
     if (!$embargo) {
       return;
     }
 
-    $current_time = $this->time->getRequestTime();
-    $current_expiration = $embargo->getExpirationDate()->getTimestamp();
-
-    if ($current_expiration > $current_time + 86400) {
+    $expiration_date_object = $embargo->getExpirationDate();
+    if (!$expiration_date_object || !$expiration_date_object->getTimestamp()) {
       return;
     }
 
-    if ($current_expiration > $current_time && $current_expiration < $current_time + 86400) {
-      $this->queueFactory->get('embargo_expiration_reindex')->createItem($data);
-      return;
+    $expiration_timestamp = $expiration_date_object->getTimestamp();
+    $current_timestamp = $this->time->getRequestTime();
+
+    // If the expiration time is still in the future, requeue it with a delay.
+    if ($expiration_timestamp > $current_timestamp) {
+      $delay = $expiration_timestamp - $current_timestamp;
+      throw new DelayedRequeueException($delay, "Embargo ID {$embargo->id()} not yet expired. Requeuing.");
     }
 
     $embargoed_node = $embargo->getEmbargoedNode();
     if ($embargoed_node) {
       $config = $this->configFactory->get('reindex_embargoes.settings');
       $selected_indexes = array_values($config->get('selected_indexes') ?? []);
+
       foreach ($selected_indexes as $index_id) {
         $index = $this->entityTypeManager->getStorage('search_api_index')->load($index_id);
-        if ($index && $index->isServerEnabled() && $index->getDatasource('entity:node')) {
-          $doc_ids = [];
-          foreach ($embargoed_node->getTranslationLanguages() as $language) {
-            $doc_ids[] = $embargoed_node->id() . ':' . $language->getId();
+        if ($index instanceof IndexInterface && $index->isServerEnabled() && $index->status()) {
+          if ($index->isValidDatasource('entity:node')) {
+            $node_ids_to_reindex = [];
+            // Item ID format is typically 'entity_id:langcode'.
+            foreach ($embargoed_node->getTranslationLanguages() as $language) {
+              $node_ids_to_reindex[] = $embargoed_node->id() . ':' . $language->getId();
+            }
+
+            if (!empty($node_ids_to_reindex)) {
+              $index->trackItemsUpdated('entity:node', $node_ids_to_reindex);
+            }
           }
-          $index->trackItemsUpdated('entity:node', $doc_ids);
         }
       }
     }

--- a/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
+++ b/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
@@ -48,8 +48,8 @@ class EmbargoExpirationReindex extends QueueWorkerBase implements ContainerFacto
    */
   public function __construct(
     array $configuration,
-          $plugin_id,
-          $plugin_definition,
+    $plugin_id,
+    $plugin_definition,
     EntityTypeManagerInterface $entity_type_manager,
     TimeInterface $time,
     ConfigFactoryInterface $config_factory

--- a/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
+++ b/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
@@ -24,7 +24,7 @@ class EmbargoExpirationReindex extends QueueWorkerBase implements ContainerFacto
   /**
    * Entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface;
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected EntityTypeManagerInterface $entityTypeManager;
 
@@ -49,6 +49,9 @@ class EmbargoExpirationReindex extends QueueWorkerBase implements ContainerFacto
    */
   protected ConfigFactoryInterface $configFactory;
 
+  /**
+   * {@inheritdoc}
+   */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $instance = new static($configuration, $plugin_id, $plugin_definition);
 
@@ -59,6 +62,9 @@ class EmbargoExpirationReindex extends QueueWorkerBase implements ContainerFacto
     return $instance;
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function processItem($data): void {
     $embargo = $this->entityTypeManager->getStorage('embargo')->load($data['embargo_id']);
     if (!$embargo) {
@@ -93,4 +99,5 @@ class EmbargoExpirationReindex extends QueueWorkerBase implements ContainerFacto
       }
     }
   }
+  
 }

--- a/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
+++ b/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\reindex_embargoes\Plugin\QueueWorker;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @QueueWorker(
+ *   id = "embargo_expiration_reindex",
+ *   title = @Translation("Embargo Expiration Reindex"),
+ *   cron = {"time" = 60}
+ * )
+ */
+class EmbargoExpirationReindex extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface;
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\Time
+   */
+  protected TimeInterface $time;
+
+  /**
+   * The queue factory.
+   *
+   * @var \Drupal\Core\Queue\QueueFactory
+   */
+  protected QueueFactory $queueFactory;
+
+  /**
+   * The configuration factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+
+    $instance->entityTypeManager = $container->get('entity_type.manager');
+    $instance->time = $container->get('datetime.time');
+    $instance->queueFactory = $container->get('queue');
+    $instance->configFactory = $container->get('config.factory');
+    return $instance;
+  }
+
+  public function processItem($data): void {
+    $embargo = $this->entityTypeManager->getStorage('embargo')->load($data['embargo_id']);
+    if (!$embargo) {
+      return;
+    }
+
+    $current_time = $this->time->getRequestTime();
+    $current_expiration = $embargo->getExpirationDate()->getTimestamp();
+
+    if ($current_expiration > $current_time + 86400) {
+      return;
+    }
+
+    if ($current_expiration > $current_time && $current_expiration < $current_time + 86400) {
+      $this->queueFactory->get('embargo_expiration_reindex')->createItem($data);
+      return;
+    }
+
+    $embargoed_node = $embargo->getEmbargoedNode();
+    if ($embargoed_node) {
+      $config = $this->configFactory->get('reindex_embargoes.settings');
+      $selected_indexes = array_values($config->get('selected_indexes') ?? []);
+      foreach ($selected_indexes as $index_id) {
+        $index = $this->entityTypeManager->getStorage('search_api_index')->load($index_id);
+        if ($index && $index->isServerEnabled() && $index->getDatasource('entity:node')) {
+          $doc_ids = [];
+          foreach ($embargoed_node->getTranslationLanguages() as $language) {
+            $doc_ids[] = $embargoed_node->id() . ':' . $language->getId();
+          }
+          $index->trackItemsUpdated('entity:node', $doc_ids);
+        }
+      }
+    }
+  }
+}

--- a/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
+++ b/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
@@ -11,6 +11,8 @@ use Drupal\Core\Queue\QueueWorkerBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
+ * QueueWorker for reindexing embargoed nodes.
+ *
  * @QueueWorker(
  *   id = "embargo_expiration_reindex",
  *   title = @Translation("Embargo Expiration Reindex"),

--- a/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
+++ b/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
@@ -52,7 +52,7 @@ class EmbargoExpirationReindex extends QueueWorkerBase implements ContainerFacto
     $plugin_definition,
     EntityTypeManagerInterface $entity_type_manager,
     TimeInterface $time,
-    ConfigFactoryInterface $config_factory
+    ConfigFactoryInterface $config_factory,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
+++ b/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
@@ -31,7 +31,7 @@ class EmbargoExpirationReindex extends QueueWorkerBase implements ContainerFacto
   /**
    * The time service.
    *
-   * @var \Drupal\Component\Datetime\Time
+   * @var \Drupal\Component\Datetime\TimeInterface
    */
   protected TimeInterface $time;
 

--- a/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
+++ b/modules/reindex_embargoes/src/Plugin/QueueWorker/EmbargoExpirationReindex.php
@@ -99,5 +99,5 @@ class EmbargoExpirationReindex extends QueueWorkerBase implements ContainerFacto
       }
     }
   }
-  
+
 }

--- a/src/Controller/IpRangeAccessExemptionController.php
+++ b/src/Controller/IpRangeAccessExemptionController.php
@@ -25,7 +25,7 @@ class IpRangeAccessExemptionController extends ControllerBase {
    * @param \Symfony\Component\HttpFoundation\Request|null $request
    *   The current request.
    */
-  public function __construct(Request $request = NULL) {
+  public function __construct(?Request $request = NULL) {
     $this->request = $request;
   }
 

--- a/src/Plugin/search_api/processor/EmbargoJoinProcessor.php
+++ b/src/Plugin/search_api/processor/EmbargoJoinProcessor.php
@@ -104,7 +104,7 @@ class EmbargoJoinProcessor extends ProcessorPluginBase implements ContainerFacto
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) : array {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) : array {
     $properties = [];
 
     if ($datasource === NULL) {

--- a/src/Plugin/search_api/processor/EmbargoProcessor.php
+++ b/src/Plugin/search_api/processor/EmbargoProcessor.php
@@ -88,7 +88,7 @@ class EmbargoProcessor extends ProcessorPluginBase implements ContainerFactoryPl
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) : array {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) : array {
     $properties = [];
 
     if ($datasource === NULL) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new module to reindex embargoed content upon embargo expiration.
  - Added an administrative settings page to select search indexes for embargo reindexing.
  - Enabled automated embargo expiration processing through scheduled queue workers.
  - Provided a Drush command to populate the embargo reindexing queue.
- **Documentation**
  - Added a detailed README with usage guidance, contributor info, and licensing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->