### PR TITLE
Hardening checks for applicable embargoes

### DIFF
--- a/src/EmbargoStorageTrait.php
+++ b/src/EmbargoStorageTrait.php
@@ -45,7 +45,7 @@ trait EmbargoStorageTrait {
   public function getApplicableEmbargoes(EntityInterface $entity): array {
     assert($this instanceof SqlContentEntityStorage);
 
-    if ($entity instanceof NodeInterface) {
+    if ($entity instanceof NodeInterface && $entity->isNew() === FALSE) {
       $properties = ['embargoed_node' => $entity->id()];
       return $this->loadByProperties($properties);
     }


### PR DESCRIPTION
## Bug

On enabling https://www.drupal.org/project/mercury_editor the node/add page whitescreens.

Stacktrace: 
`The website encountered an unexpected error. Try again later.
Drupal\Core\Database\InvalidQueryException: Query condition 'embargo.embargoed_node IN ()' cannot be empty. in Drupal\Core\Database\Query\Condition->condition() (line 108 of core/lib/Drupal/Core/Database/Query/Condition.php).
`

Do not check for applicable embargoes if a new object is being added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Embargo evaluation now ignores newly created (unsaved) content, preventing premature embargo lookups on drafts. Embargo rules continue to apply once content is saved.
  * No changes to embargo handling for media and files; their behavior remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->