### PR TITLE
DGI9-610: Prevent page_cache caching where an `ip` cache context is relevant.

### DIFF
--- a/embargo.services.yml
+++ b/embargo.services.yml
@@ -69,3 +69,7 @@ services:
       - '@entity_type.manager'
     tags:
       - { name: 'cache.context' }
+  embargo.page_cache_request_policy.deny_ip_dependent_response:
+    class: Drupal\embargo\PageCache\DenyIpDependentResponse
+    tags:
+      { name: page_cache_response_policy }

--- a/embargo.services.yml
+++ b/embargo.services.yml
@@ -72,4 +72,4 @@ services:
   embargo.page_cache_request_policy.deny_ip_dependent_response:
     class: Drupal\embargo\PageCache\DenyIpDependentResponse
     tags:
-      { name: page_cache_response_policy }
+      - { name: page_cache_response_policy }

--- a/modules/migrate_embargoes_to_embargo/src/Plugin/migrate/source/Entity.php
+++ b/modules/migrate_embargoes_to_embargo/src/Plugin/migrate/source/Entity.php
@@ -56,7 +56,7 @@ class Entity extends SourcePluginBase implements ContainerFactoryPluginInterface
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    MigrationInterface $migration = NULL,
+    ?MigrationInterface $migration = NULL,
   ) {
     return new static(
       $configuration,

--- a/src/Controller/IpRangeAccessExemptionController.php
+++ b/src/Controller/IpRangeAccessExemptionController.php
@@ -25,7 +25,7 @@ class IpRangeAccessExemptionController extends ControllerBase {
    * @param \Symfony\Component\HttpFoundation\Request|null $request
    *   The current request.
    */
-  public function __construct(Request $request = NULL) {
+  public function __construct(?Request $request = NULL) {
     $this->request = $request;
   }
 

--- a/src/Controller/IpRangeAccessExemptionController.php
+++ b/src/Controller/IpRangeAccessExemptionController.php
@@ -4,7 +4,6 @@ namespace Drupal\embargo\Controller;
 
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Controller\ControllerBase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -13,41 +12,19 @@ use Symfony\Component\HttpFoundation\Request;
 class IpRangeAccessExemptionController extends ControllerBase {
 
   /**
-   * The HTTP request.
-   *
-   * @var \Symfony\Component\HttpFoundation\Request
-   */
-  protected $request;
-
-  /**
-   * Constructs an IP access denied controller.
-   *
-   * @param \Symfony\Component\HttpFoundation\Request|null $request
-   *   The current request.
-   */
-  public function __construct(?Request $request = NULL) {
-    $this->request = $request;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('request_stack')->getCurrentRequest());
-  }
-
-  /**
    * Formats a response for an IP access denied page.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request being served.
    *
    * @return array
    *   Renderable array of markup for IP access denied.
    */
-  public function response() {
+  public function response(Request $request) : array {
     $ranges = [];
     $cache_tags = [];
     /** @var \Drupal\embargo\IpRangeInterface[] $entities */
-    $entities = $this->entityTypeManager()->getStorage('embargo_ip_range')->loadMultiple($this->request->query->all()['ranges'] ?? []);
+    $entities = $this->entityTypeManager()->getStorage('embargo_ip_range')->loadMultiple($request->query->all()['ranges'] ?? []);
     foreach ($entities as $entity) {
       $ranges[] = [
         'label' => $entity->label(),
@@ -58,7 +35,7 @@ class IpRangeAccessExemptionController extends ControllerBase {
 
     return [
       '#theme' => 'embargo_ip_access_exemption',
-      '#resources' => $this->request->query->all()['resources'] ?? [],
+      '#resources' => $request->query->all()['resources'] ?? [],
       '#ranges' => $ranges,
       '#contact_email' => $this->config('embargo.settings')->get('contact_email'),
       '#cache' => [

--- a/src/PageCache/DenyIpDependentResponse.php
+++ b/src/PageCache/DenyIpDependentResponse.php
@@ -19,6 +19,16 @@ use Symfony\Component\HttpFoundation\Response;
 class DenyIpDependentResponse implements ResponsePolicyInterface {
 
   /**
+   * Cache contexts of which the presence should suppress page_cache.
+   */
+  protected const IP_CONTEXTS = [
+    'ip.embargo_range',
+    // XXX: `ip.embargo_range` could be optimized away if the `ip` context
+    // itself is added, so let's also account for it.
+    'ip',
+  ];
+
+  /**
    * {@inheritDoc}
    */
   public function check(Response $response, Request $request) : ?string {
@@ -37,7 +47,7 @@ class DenyIpDependentResponse implements ResponsePolicyInterface {
 
     $cache_contexts = $access_result->getCacheContexts();
 
-    if (array_intersect(['ip', 'ip.embargo_range'], $cache_contexts)) {
+    if (array_intersect(static::IP_CONTEXTS, $cache_contexts)) {
       // Access result has relevant context; avoiding page cache.
       return ResponsePolicyInterface::DENY;
     }

--- a/src/PageCache/DenyIpDependentResponse.php
+++ b/src/PageCache/DenyIpDependentResponse.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\embargo\PageCache;
+
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\PageCache\ResponsePolicyInterface;
+use Drupal\Core\Routing\AccessAwareRouterInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Avoid page_cache when IP embargoes are in play.
+ *
+ * IP embargoes break the assumption made by page_cache that all anonymous
+ * requests are equivalent, so let's avoid allowing things to go to the
+ * page_cache for anonymous users when an access result has the
+ * `ip.embargo_range` (or wider `ip`) context.
+ */
+class DenyIpDependentResponse implements ResponsePolicyInterface {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function check(Response $response, Request $request) : ?string {
+    if (!$request->attributes->has(AccessAwareRouterInterface::ACCESS_RESULT)) {
+      // No access result; unable to check.
+      return NULL;
+    }
+
+    /** @var \Drupal\Core\Access\AccessResultInterface $access_result */
+    $access_result = $request->attributes->get(AccessAwareRouterInterface::ACCESS_RESULT);
+
+    if (!($access_result instanceof RefinableCacheableDependencyInterface)) {
+      // Access result is not cacheable; unable to check cache contexts.
+      return NULL;
+    }
+
+    $cache_contexts = $access_result->getCacheContexts();
+
+    if (array_intersect(['ip', 'ip.embargo_range'], $cache_contexts)) {
+      // Access result has relevant context; avoiding page cache.
+      return ResponsePolicyInterface::DENY;
+    }
+
+    // No candidate IP cache contexts present on access result; passing.
+    return NULL;
+  }
+
+}

--- a/src/Plugin/search_api/processor/EmbargoJoinProcessor.php
+++ b/src/Plugin/search_api/processor/EmbargoJoinProcessor.php
@@ -104,7 +104,7 @@ class EmbargoJoinProcessor extends ProcessorPluginBase implements ContainerFacto
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) : array {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) : array {
     $properties = [];
 
     if ($datasource === NULL) {

--- a/src/Plugin/search_api/processor/EmbargoProcessor.php
+++ b/src/Plugin/search_api/processor/EmbargoProcessor.php
@@ -88,7 +88,7 @@ class EmbargoProcessor extends ProcessorPluginBase implements ContainerFactoryPl
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) : array {
+  public function getPropertyDefinitions(?DatasourceInterface $datasource = NULL) : array {
     $properties = [];
 
     if ($datasource === NULL) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a page-cache policy to prevent caching when IP-based embargo contexts are present, improving cache correctness for IP-dependent embargoes.

* **Chores**
  * Made request handling and parameter nullability more flexible across migration, controller, and search components for improved robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->